### PR TITLE
Add events endpoint

### DIFF
--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -48,7 +48,9 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (event *ctypes.Res
 	if err != nil {
 		return
 	}
-	defer env.EventBus.Unsubscribe(context.Background(), addr, q)
+	defer func() {
+		_ = env.EventBus.Unsubscribe(subCtx, addr, q)
+	}()
 
 	select {
 	case msg := <-sub.Out():

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -49,7 +49,9 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (*ctypes.ResultEve
 		return nil, err
 	}
 	defer func() {
-		_ = env.EventBus.Unsubscribe(subCtx, addr, q)
+		// unsubscribing shouldn't take too long. `maxWaitTime` is not a precise
+		// timeout anyway...
+		_ = env.EventBus.Unsubscribe(context.Background(), addr, q)
 	}()
 
 	var event *ctypes.ResultEvent

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -18,7 +18,7 @@ const (
 	maxQueryLength = 512
 )
 
-// Poll for new ABCI events.
+// Events polls for new ABCI events that match the `query`
 func Events(ctx *rpctypes.Context, query, maxWaitTime string) (event *ctypes.ResultEvent, err error) {
 	wt, err := time.ParseDuration(maxWaitTime)
 	if err != nil {

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -63,7 +63,7 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (*ctypes.ResultEve
 		err = fmt.Errorf("subscription was canceled, reason: %w", sub.Err())
 	}
 
-	return event, nil
+	return event, err
 }
 
 // Subscribe for events via WebSocket.

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -32,12 +32,12 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (event *ctypes.Res
 		return
 	}
 
-	const constMinWaitTime = 1 * time.Second
-	const constMaxWaitTime = 30 * time.Second
-	if wt < constMinWaitTime {
-		wt = constMinWaitTime
-	} else if wt > constMaxWaitTime {
-		wt = constMaxWaitTime
+	const timeoutMin = 1 * time.Second
+	const timeoutMax = 30 * time.Second
+	if wt < timeoutMin {
+		wt = timeoutMin
+	} else if wt > timeoutMax {
+		wt = timeoutMax
 	}
 
 	subCtx, cancel := context.WithTimeout(ctx.Context(), wt)

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -54,13 +54,20 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (*ctypes.ResultEve
 		_ = env.EventBus.Unsubscribe(context.Background(), addr, q)
 	}()
 
-		select {
+	select {
 	case msg := <-sub.Out():
-		return &ctypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}, nil
+		event := &ctypes.ResultEvent{
+			Query:  query,
+			Data:   msg.Data(),
+			Events: msg.Events(),
+		}
+		return event, nil
 	case <-subCtx.Done():
-		return nil, fmt.Errorf("timeout of %s expired", wt)
+		err = fmt.Errorf("timeout of %s expired", wt)
+		return nil, err
 	case <-sub.Cancelled():
-		return nil, fmt.Errorf("subscription was canceled, reason: %w", sub.Err())
+		err = fmt.Errorf("subscription was canceled, reason: %w", sub.Err())
+		return nil, err
 	}
 }
 

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -54,18 +54,14 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (*ctypes.ResultEve
 		_ = env.EventBus.Unsubscribe(context.Background(), addr, q)
 	}()
 
-	var event *ctypes.ResultEvent
-
-	select {
+		select {
 	case msg := <-sub.Out():
-		event = &ctypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}
+		return &ctypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}, nil
 	case <-subCtx.Done():
-		err = fmt.Errorf("timeout of %s expired", wt)
+		return nil, fmt.Errorf("timeout of %s expired", wt)
 	case <-sub.Cancelled():
-		err = fmt.Errorf("subscription was canceled, reason: %w", sub.Err())
+		return nil, fmt.Errorf("subscription was canceled, reason: %w", sub.Err())
 	}
-
-	return event, err
 }
 
 // Subscribe for events via WebSocket.

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -34,6 +34,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"consensus_params":     rpc.NewRPCFunc(ConsensusParams, "height"),
 	"unconfirmed_txs":      rpc.NewRPCFunc(UnconfirmedTxs, "limit"),
 	"num_unconfirmed_txs":  rpc.NewRPCFunc(NumUnconfirmedTxs, ""),
+	"events":               rpc.NewRPCFunc(Events, "query,max_wait_time"),
 
 	// tx broadcast API
 	"broadcast_tx_commit": rpc.NewRPCFunc(BroadcastTxCommit, "tx"),


### PR DESCRIPTION
Add a new `/events` RPC endpoint. This simply calls into whatever code a websockets subscription was already calling into.