### PR TITLE
Use the event log to fetch ABCI events during RPC calls

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -755,10 +755,11 @@ func NewNode(config *cfg.Config,
 	if err != nil {
 		return nil, err
 	}
+	query, _ := tmquery.New("tm.event='NewBlock'")
 	sub, err := eventBus.SubscribeUnbuffered(
 		context.Background(),
 		"EventLog",
-		tmquery.Empty{},
+		query,
 	)
 	if err != nil {
 		return nil, err

--- a/node/node.go
+++ b/node/node.go
@@ -764,7 +764,7 @@ func NewNode(config *cfg.Config,
 		return nil, err
 	}
 	go func(logger log.Logger) {
-		// defer eventBus.UnsubscribeAll()
+		defer eventBus.UnsubscribeAll(context.Background(), "EventLog")
 		for {
 			select {
 			case msg := <-sub.Out():

--- a/node/node.go
+++ b/node/node.go
@@ -765,7 +765,12 @@ func NewNode(config *cfg.Config,
 		return nil, err
 	}
 	go func(logger log.Logger) {
-		defer eventBus.UnsubscribeAll(context.Background(), "EventLog")
+		defer func() {
+			err := eventBus.UnsubscribeAll(context.Background(), "EventLog")
+			if err != nil {
+				logger.Error("Failed to unsubscribe from events", "err", err)
+			}
+		}()
 		for {
 			select {
 			case msg := <-sub.Out():

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -8,6 +8,7 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/libs/events/eventlog"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	mempl "github.com/tendermint/tendermint/mempool"
@@ -92,6 +93,7 @@ type Environment struct {
 	BlockIndexer     indexer.BlockIndexer
 	ConsensusReactor *consensus.Reactor
 	EventBus         *types.EventBus // thread safe
+	EventLog         *eventlog.Log
 	Mempool          mempl.Mempool
 
 	Logger log.Logger

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -57,7 +57,10 @@ func Events(ctx *rpctypes.Context, query, maxWaitTime string) (*ctypes.ResultEve
 	var event *ctypes.ResultEvent
 
 	accept := func(itm *eventlog.Item) error {
-		matches, _ := q.Matches(itm.Events)
+		matches, err := q.Matches(itm.Events)
+		if err != nil {
+			return err
+		}
 		if cursorInRange(itm.Cursor, before, after) && matches {
 			event = &ctypes.ResultEvent{
 				Query:  query,


### PR DESCRIPTION
Based on https://github.com/heliaxdev/tendermint/pull/163

This PR uses the event log to fetch ABCI events during `/events` RPC calls, instead of subscribing to the pubsub layer directly.